### PR TITLE
再レンダリングを防止

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
 const config = {
-  swcMinify: true,
   reactStrictMode: true,
   pageExtensions: ["page.tsx", "page.ts"],
 };


### PR DESCRIPTION
swcMinifyをfalseにしたら、googlemapの再レンダリングがなくなった。